### PR TITLE
📌 (feat) add external name service support

### DIFF
--- a/Chart.yaml
+++ b/Chart.yaml
@@ -23,7 +23,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.1.27
+version: 0.1.28
 
 
 # This is the version number of the application being deployed. This version number should be

--- a/templates/pvc.yaml
+++ b/templates/pvc.yaml
@@ -23,7 +23,7 @@ metadata:
     chart: "{{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}"
 spec:
   accessModes:
-    - ReadWriteMany
+    {{- toYaml .Values.accessModes | nindent 2 }}
   resources:
     requests:
       storage: {{ .Values.storage }}

--- a/templates/service.yaml
+++ b/templates/service.yaml
@@ -1,3 +1,4 @@
+{{- if eq .Values.service.enabled "true"}}
 # Copyright 2020 Keyporttech Inc.
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -13,7 +14,6 @@
 # This is a YAML-formatted file.
 # Declare variables to be passed into your templates.
 
-
 apiVersion: v1
 kind: Service
 metadata:
@@ -22,6 +22,9 @@ metadata:
     {{- include "dynamodb-helm-chart.labels" . | nindent 4 }}
 spec:
   type: {{ .Values.service.type }}
+  {{- if .Values.service.externalName }}
+  externalName: {{ .Values.service.externalName | quote }}
+  {{- end }}
   ports:
     - port: 8000
       targetPort: 8000
@@ -33,3 +36,4 @@ spec:
       name: admin
   selector:
     {{- include "dynamodb-helm-chart.selectorLabels" . | nindent 4 }}
+{{- end }}

--- a/templates/service.yaml
+++ b/templates/service.yaml
@@ -23,7 +23,7 @@ metadata:
 spec:
   type: {{ .Values.service.type }}
   {{- if .Values.service.externalName }}
-  externalName: {{ .Values.service.externalName | quote }}
+  externalName: {{ .Values.service.externalName | quote }}
   {{- end }}
   ports:
     - port: 8000

--- a/templates/service.yaml
+++ b/templates/service.yaml
@@ -1,4 +1,4 @@
-{{- if eq .Values.service.enabled "true"}}
+{{- if eq .Values.service.enabled true }}
 # Copyright 2020 Keyporttech Inc.
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -23,7 +23,7 @@ metadata:
 spec:
   type: {{ .Values.service.type }}
   {{- if .Values.service.externalName }}
-  externalName: {{ .Values.service.externalName | quote }}
+  externalName: {{ .Values.service.externalName | quote }}
   {{- end }}
   ports:
     - port: 8000

--- a/values.yaml
+++ b/values.yaml
@@ -99,6 +99,9 @@ affinity: {}
 # type of storage pvc, directVolume -defaults to emptyDir
 storageType: emptyDir
 
+accessModes:
+  - ReadWriteMany
+
 # example pvc values
 # storage: "500Mi"
 # storageClassName: ""

--- a/values.yaml
+++ b/values.yaml
@@ -55,7 +55,11 @@ securityContext: {}
   # runAsUser: 1000
 
 service:
-  type: ClusterIP
+  enabled: true
+  type: ClusterIP # Can be ClusterIP or ExternalName
+  
+  # If type: ExternalName
+  # externalName: ""
 
 ingress:
   enabled: false


### PR DESCRIPTION
## New features
- Service creation is now optional. Added the value `externalName` when creating a service of type `externalName`
- AccessModes can be customizable for `PVC`